### PR TITLE
Created the src/obj folder

### DIFF
--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Before this patch, building penguincoind required the builder to make the obj directory.
